### PR TITLE
Update OrbitStore.js

### DIFF
--- a/src/stores/OrbitStore.js
+++ b/src/stores/OrbitStore.js
@@ -87,6 +87,7 @@ class OrbitStore {
             console.log(kv.get('volume'))
             // 100
         });
+        await kv.load()
 
 
 
@@ -120,6 +121,7 @@ class OrbitStore {
 
         console.log(`Joined #${channelName}, ${feed.address.toString()}`)
 
+        await feed.load()
         feed.add(data)
 
 


### PR DESCRIPTION
load persisted entries.
its important to call .load on orbit db stores if you wish to load local entries from previous sessions.

calling load is what eventually triggers the ready event for stores. if a db has already been loaded with load before you are listening for the ready event you will not see the ready event fire because it already happened.

adding entries to a db before load has finished will result in all persisted local entries being over written.